### PR TITLE
add search by update time

### DIFF
--- a/simplecodetester-frontend/src/components/checklist/CheckList.vue
+++ b/simplecodetester-frontend/src/components/checklist/CheckList.vue
@@ -27,7 +27,7 @@
             class="mx-5 mb-2"
             v-model="search"
             :append-icon="searchIcon"
-            label="Search for category, id, check name or author..."
+            label="Search for category, id, check name, author or update time ('after <ISO8601>')..."
             single-line
           ></v-text-field>
 
@@ -213,6 +213,12 @@ export default class CheckList extends Vue {
     }
     if (check.id.toString().indexOf(search) !== -1) {
       return true;
+    }
+    if (search.startsWith("after ")) {
+      const givenTimeMS = Date.parse(search.replace("after ", "").trim());
+      if (!isNaN(givenTimeMS) && check.updateTimeMS >= givenTimeMS) {
+        return true;
+      }
     }
     return false;
   }

--- a/simplecodetester-frontend/src/components/checklist/CheckTypes.ts
+++ b/simplecodetester-frontend/src/components/checklist/CheckTypes.ts
@@ -18,6 +18,7 @@ export class CheckBase {
   checkType: string | null;
   creationTime: string;
   updateTime: string | null;
+  updateTimeMS: number;
 
   constructor(
     id: number,
@@ -27,7 +28,8 @@ export class CheckBase {
     category: CheckCategory,
     checkType: string | null,
     creationTime: string,
-    updateTime: string | null
+    updateTime: string | null,
+    updateTimeMS: number
   ) {
     this.id = id;
     this.creator = creator;
@@ -37,6 +39,7 @@ export class CheckBase {
     this.checkType = checkType;
     this.creationTime = creationTime;
     this.updateTime = updateTime;
+    this.updateTimeMS = updateTimeMS;
   }
 
   static fromJson(json: any): CheckBase {
@@ -44,6 +47,11 @@ export class CheckBase {
     const updateTime = json.updateTime === undefined
       ? null
       : dateFormat.format(new Date(json.updateTime));
+    const updateTimeMS = json.updateTime !== undefined
+      ? json.updateTime
+      : json.creationTime !== undefined
+      ? json.creationTime
+      : 0; // default: unix epoch -> old checks without the fields won't be found
 
     return new CheckBase(
       json.id,
@@ -53,7 +61,8 @@ export class CheckBase {
       new CheckCategory(json.category.name, json.category.id),
       json.checkType,
       creationTime,
-      updateTime
+      updateTime,
+      updateTimeMS
     );
   }
 }


### PR DESCRIPTION
Disclaimer: This is not tested! I didn't know how to really test this without setting up a whole identical infrastructure, so I didn't.

This should enable users to search the "All Checks" list for checks, that were updated or created after a given point in time, in the following form: `after <any ISO8601 time>`. For example: `after 2022-03-28T11:00`.

Let me know if this does not suit your desired style of code.