### PR TITLE
TerminalScanner hasNextLine() method

### DIFF
--- a/SimpleCodeTester-Executor/src/main/java/me/ialistannen/simplecodetester/execution/diana/TerminalScanner.java
+++ b/SimpleCodeTester-Executor/src/main/java/me/ialistannen/simplecodetester/execution/diana/TerminalScanner.java
@@ -25,6 +25,10 @@ public class TerminalScanner implements AutoCloseable {
     return fileContentOffset < fileContent.length;
   }
 
+  public boolean hasNextLine() {
+    return hasNext();
+  }
+
   public String nextLine() {
     if (fileContent == null) {
       return Terminal.readLine();


### PR DESCRIPTION
Die Standard-Lösung für dieses Semester Programmieren benutzt java.util.Scanner leicht anders. Statt scanner.hasNext() wird jetzt die Methode scanner.hasNextLine() genutzt. Ich habe kurz experimentiert mit einem Beispiel und bin darauf gekommen, dass ich das gleiche Verhalten mit scanner.hasNext() erziele.
Daher die Änderung, die eine hasNextLine() Methode in me.ialistannen.simplecodetester.execution.diana.TerminalScanner definiert.