### PR TITLE
Fix incorrect class name generation from file path when path contains /java

### DIFF
--- a/SimpleCodeTester-Executor/src/main/java/me/ialistannen/simplecodetester/execution/compilation/memory/ClassFileManager.java
+++ b/SimpleCodeTester-Executor/src/main/java/me/ialistannen/simplecodetester/execution/compilation/memory/ClassFileManager.java
@@ -42,8 +42,8 @@ class ClassFileManager extends ForwardingJavaFileManager<StandardJavaFileManager
 
   String sanitizeToClassName(String path) {
     return path
-        .replace("/", ".")
-        .replace(".java", "");
+        .replace(".java", "")
+        .replace("/", ".");
   }
 
   /**


### PR DESCRIPTION
The original implementation of this method led to incorrect class name generation when the file path contained the substring /java.

Previously, a file path like "com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java" would incorrectly generate the class name "com.amazon.sqsmessaging.AmazonSQSExtendedClient". This was due to the premature removal of the /java segment.